### PR TITLE
Escaping quotes for Windows systems

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 
 plugins {
     id("application")
@@ -42,14 +43,14 @@ val experimentGeneratedCodeData = mapOf(
     "variationKey" to "TEST_VARIATION"
 )
 val serializedData: String = run {
-    val json = Json(kotlinx.serialization.json.JsonConfiguration.Stable)
+    val json = Json(JsonConfiguration.Stable)
     val mapSerializer = MapSerializer(String.serializer(), String.serializer())
     json.stringify(mapSerializer, experimentGeneratedCodeData)
 }
 
 tasks.withType<Test> {
     useJUnitPlatform()
-    systemProperty("experimentGeneratedCodeData", serializedData)
+    systemProperty("experimentGeneratedCodeData", serializedData.replace("\"", "\\\""))
 }
 
 tasks.named<Test>("test") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,12 +45,17 @@ val experimentGeneratedCodeData = mapOf(
 val serializedData: String = run {
     val json = Json(JsonConfiguration.Stable)
     val mapSerializer = MapSerializer(String.serializer(), String.serializer())
-    json.stringify(mapSerializer, experimentGeneratedCodeData)
+    val jsonString = json.stringify(mapSerializer, experimentGeneratedCodeData)
+    if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
+        jsonString.replace("\"", "\\\"")
+    } else {
+        jsonString
+    }
 }
 
 tasks.withType<Test> {
     useJUnitPlatform()
-    systemProperty("experimentGeneratedCodeData", serializedData.replace("\"", "\\\""))
+    systemProperty("experimentGeneratedCodeData", serializedData)
 }
 
 tasks.named<Test>("test") {


### PR DESCRIPTION
When setting system properties to expose the Json string from the serialized map, Windows systems don't escape the quotes which leads to an unexpected json when deserializing.