### PR TITLE
Remove listExperiments function

### DIFF
--- a/src/main/kotlin/com/patxi/poetimizely/Main.kt
+++ b/src/main/kotlin/com/patxi/poetimizely/Main.kt
@@ -5,7 +5,6 @@ package com.patxi.poetimizely
 import com.patxi.poetimizely.generator.buildExperimentObject
 import com.patxi.poetimizely.optimizely.OptimizelyService
 import com.patxi.poetimizely.optimizely.buildOptimizelyService
-import com.patxi.poetimizely.optimizely.listExperiments
 import kotlinx.coroutines.runBlocking
 
 fun main(args: Array<String>) {
@@ -15,7 +14,7 @@ fun main(args: Array<String>) {
 
     val service: OptimizelyService = buildOptimizelyService(optimizelyToken)
     runBlocking {
-        val experiments = listExperiments(projectId, service)
+        val experiments = service.listExperiments(projectId)
         experiments.forEach {
             buildExperimentObject(it)
         }

--- a/src/main/kotlin/com/patxi/poetimizely/optimizely/Optimizely.kt
+++ b/src/main/kotlin/com/patxi/poetimizely/optimizely/Optimizely.kt
@@ -18,6 +18,3 @@ fun buildOptimizelyService(optimizelyToken: String): OptimizelyService {
 
     return retrofit.create(OptimizelyService::class.java)
 }
-
-suspend fun listExperiments(projectId: Long, service: OptimizelyService): List<Experiment> =
-    service.listExperiments(projectId)


### PR DESCRIPTION
It doesn’t appear like we need the listExperiments() function, since it’s just wrapping a method call to the OptimizelyService instanced which is a parameter of the function. I propose we remove it 😁.