### PR TITLE
Testing ExperimentsClient and Retrofit client building

### DIFF
--- a/src/main/kotlin/com/patxi/poetimizely/optimizely/Optimizely.kt
+++ b/src/main/kotlin/com/patxi/poetimizely/optimizely/Optimizely.kt
@@ -4,13 +4,13 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-fun buildExperimentsService(optimizelyToken: String): ExperimentsService =
-    authedRetrofit(optimizelyToken).create(ExperimentsService::class.java)
+fun buildExperimentsService(retrofit: Retrofit): ExperimentsService =
+    retrofit.create(ExperimentsService::class.java)
 
-fun buildFeaturesService(optimizelyToken: String): FeaturesService =
-    authedRetrofit(optimizelyToken).create(FeaturesService::class.java)
+fun buildFeaturesService(retrofit: Retrofit): FeaturesService =
+    retrofit.create(FeaturesService::class.java)
 
-fun authedRetrofit(optimizelyToken: String): Retrofit {
+fun authenticatedRetrofit(optimizelyToken: String): Retrofit {
     val httpClient = OkHttpClient.Builder().addInterceptor { chain ->
         val newRequest = chain.request().newBuilder().addHeader("Authorization", "Bearer $optimizelyToken").build()
         chain.proceed(newRequest)

--- a/src/main/kotlin/com/patxi/poetimizely/optimizely/Optimizely.kt
+++ b/src/main/kotlin/com/patxi/poetimizely/optimizely/Optimizely.kt
@@ -10,16 +10,15 @@ fun buildExperimentsService(optimizelyToken: String): ExperimentsService =
 fun buildFeaturesService(optimizelyToken: String): FeaturesService =
     authedRetrofit(optimizelyToken).create(FeaturesService::class.java)
 
-private fun authedRetrofit(optimizelyToken: String): Retrofit {
+fun authedRetrofit(optimizelyToken: String): Retrofit {
     val httpClient = OkHttpClient.Builder().addInterceptor { chain ->
         val newRequest = chain.request().newBuilder().addHeader("Authorization", "Bearer $optimizelyToken").build()
         chain.proceed(newRequest)
     }.build()
 
-    val retrofit = Retrofit.Builder()
+    return Retrofit.Builder()
         .baseUrl("https://api.optimizely.com/v2/")
         .addConverterFactory(GsonConverterFactory.create())
         .client(httpClient)
         .build()
-    return retrofit
 }

--- a/src/main/kotlin/com/patxi/poetimizely/plugin/GeneratorTask.kt
+++ b/src/main/kotlin/com/patxi/poetimizely/plugin/GeneratorTask.kt
@@ -2,6 +2,7 @@ package com.patxi.poetimizely.plugin
 
 import com.patxi.poetimizely.generator.Generator
 import com.patxi.poetimizely.optimizely.ExperimentsService
+import com.patxi.poetimizely.optimizely.authenticatedRetrofit
 import com.patxi.poetimizely.optimizely.buildExperimentsService
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.DefaultTask
@@ -19,7 +20,8 @@ open class GeneratorTask : DefaultTask() {
             logger.error("Skipping generator task as missing required arguments")
             return
         }
-        val service: ExperimentsService = buildExperimentsService(optimizelyToken)
+        val authenticatedRetrofit = authenticatedRetrofit(optimizelyToken)
+        val service: ExperimentsService = buildExperimentsService(authenticatedRetrofit)
         val generator = Generator()
         runBlocking {
             val experiments = service.listExperiments(optimizelyProjectId)

--- a/src/test/kotlin/com/patxi/poetimizely/generator/base/ExperimentsClientTest.kt
+++ b/src/test/kotlin/com/patxi/poetimizely/generator/base/ExperimentsClientTest.kt
@@ -1,0 +1,42 @@
+package com.patxi.poetimizely.generator.base
+
+import com.optimizely.ab.Optimizely
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class ExperimentsClientTest : BehaviorSpec({
+    given("An experiment with two variants") {
+        val experiment = object : Experiment<ExperimentVariants> {
+            override val key = "Experiment"
+            override val variants = ExperimentVariants.values()
+        }
+        and("A experiments client with a mock Optimizely instance") {
+            val userId = "userId"
+            val optimizelyMock = mockk<Optimizely> {
+                every { activate(experiment.key, userId, emptyMap<String, Any>()) } returns mockk {
+                    every { key } returns ExperimentVariants.Variant1.key
+                }
+            }
+            val experimentsClient: ExperimentsClient = object : ExperimentsClient(optimizelyMock, userId) {
+                override fun getAllExperiments() = listOf(experiment)
+            }
+            `when`("Getting the variant for the experiment") {
+                val variant = experimentsClient.getVariantForExperiment(experiment)
+                then("The returned variant by the client is the expected one") {
+                    variant shouldBe ExperimentVariants.Variant1
+                }
+            }
+        }
+    }
+})
+
+private enum class ExperimentVariants : Variant {
+    Variant1 {
+        override val key = "Variant1"
+    },
+    Variant2 {
+        override val key = "Variant2"
+    },
+}

--- a/src/test/kotlin/com/patxi/poetimizely/optimizely/OptimizelyTest.kt
+++ b/src/test/kotlin/com/patxi/poetimizely/optimizely/OptimizelyTest.kt
@@ -1,0 +1,23 @@
+package com.patxi.poetimizely.optimizely
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import okhttp3.Request
+
+class OptimizelyTest : BehaviorSpec({
+    given("An Optimizely token") {
+        val optimizelyToken = "token"
+        and("A Retrofit instance") {
+            val authedRetrofit = authedRetrofit(optimizelyToken)
+            `when`("Making a request using the Retrofit instance") {
+                val request = authedRetrofit.callFactory()
+                    .newCall(Request.Builder().url("https://github.com/patxibocos/poetimizely").build())
+                val response = request.execute()
+                then("Original request should contain the Optimizely token in the headers") {
+                    response.request().header("Authorization") shouldBe "Bearer $optimizelyToken"
+                    authedRetrofit.baseUrl().host() shouldBe "api.optimizely.com"
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/patxi/poetimizely/optimizely/OptimizelyTest.kt
+++ b/src/test/kotlin/com/patxi/poetimizely/optimizely/OptimizelyTest.kt
@@ -8,14 +8,14 @@ class OptimizelyTest : BehaviorSpec({
     given("An Optimizely token") {
         val optimizelyToken = "token"
         and("A Retrofit instance") {
-            val authedRetrofit = authedRetrofit(optimizelyToken)
+            val authenticatedRetrofit = authenticatedRetrofit(optimizelyToken)
             `when`("Making a request using the Retrofit instance") {
-                val request = authedRetrofit.callFactory()
+                val request = authenticatedRetrofit.callFactory()
                     .newCall(Request.Builder().url("https://github.com/patxibocos/poetimizely").build())
                 val response = request.execute()
                 then("Original request should contain the Optimizely token in the headers") {
                     response.request().header("Authorization") shouldBe "Bearer $optimizelyToken"
-                    authedRetrofit.baseUrl().host() shouldBe "api.optimizely.com"
+                    authenticatedRetrofit.baseUrl().host() shouldBe "api.optimizely.com"
                 }
             }
         }


### PR DESCRIPTION
This PR adds tests for:
- **ExperimentsClient**: given a mock instance of Optimizely, verifies that the behavior of the client is as expected
- **authedRetrofit** function: verify that the requests are sending the auth token as a header