### PR TITLE
Defining publish plugin GitHub workflow

### DIFF
--- a/.github/workflows/publish_plugin.yml
+++ b/.github/workflows/publish_plugin.yml
@@ -1,0 +1,18 @@
+name: publish
+
+# Triggers when a new release is created
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish_plugin:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Publish the plugin to Gradle Plugin Portal (key and secret are stored as secrets in the repo)
+    - name: Gradle publishPlugins
+      run: ./gradlew publishPlugins -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}


### PR DESCRIPTION
Defining a new workflow that will be triggered just when a new release is published.
It just runs `publishPlugins` Gradle task using Gradle publish key and secret that are stored as secrets in the repo.
[Creating encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets)
[Using encrypted secrets in a workflow](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow)