### PR TITLE
Versioning to buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.patxi.poetimizely.poetimizelyVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "com.patxi"
-version = poetimizelyVersion(file("version.properties"))
+version = poetimizelyVersion()
 
 plugins {
     `java-gradle-plugin`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
+import com.patxi.poetimizely.poetimizelyVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "com.patxi"
-version = "1.0.0-SNAPSHOT"
+version = poetimizelyVersion(file("version.properties"))
 
 plugins {
     `java-gradle-plugin`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.patxi.poetimizely.bumpVersion
 import com.patxi.poetimizely.poetimizelyVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -71,4 +72,9 @@ pluginBundle {
     website = "https://github.com/patxibocos/poetimizely"
     vcsUrl = "https://github.com/patxibocos/poetimizely"
     tags = listOf("optimizely", "kotlin", "typesafe", "kotlinpoet")
+}
+
+tasks.register("bumpVersion") {
+    val newVersion = property("version") ?: return@register
+    bumpVersion(newVersion.toString())
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/com/patxi/poetimizely/versioning.kt
+++ b/buildSrc/src/main/kotlin/com/patxi/poetimizely/versioning.kt
@@ -1,0 +1,12 @@
+package com.patxi.poetimizely
+
+import java.io.File
+import java.util.Properties
+
+fun poetimizelyVersion(versionPropertiesFile: File): String = Properties().run {
+    load(versionPropertiesFile.inputStream())
+    val major = get("version.major")
+    val minor = get("version.minor")
+    val patch = get("version.patch")
+    "$major.$minor.$patch"
+}

--- a/buildSrc/src/main/kotlin/com/patxi/poetimizely/versioning.kt
+++ b/buildSrc/src/main/kotlin/com/patxi/poetimizely/versioning.kt
@@ -7,7 +7,7 @@ fun poetimizelyVersion(): String = Properties().apply {
     load(getVersioningFile().inputStream())
 }.getProperty("version")
 
-fun bumpVersionTo(version: String): Unit = Properties().apply {
+fun bumpVersion(version: String): Unit = Properties().apply {
     put("version", version)
 }.store(getVersioningFile().outputStream(), null)
 

--- a/buildSrc/src/main/kotlin/com/patxi/poetimizely/versioning.kt
+++ b/buildSrc/src/main/kotlin/com/patxi/poetimizely/versioning.kt
@@ -3,10 +3,12 @@ package com.patxi.poetimizely
 import java.io.File
 import java.util.Properties
 
-fun poetimizelyVersion(versionPropertiesFile: File): String = Properties().run {
-    load(versionPropertiesFile.inputStream())
-    val major = get("version.major")
-    val minor = get("version.minor")
-    val patch = get("version.patch")
-    "$major.$minor.$patch"
-}
+fun poetimizelyVersion(): String = Properties().apply {
+    load(getVersioningFile().inputStream())
+}.getProperty("version")
+
+fun bumpVersionTo(version: String): Unit = Properties().apply {
+    put("version", version)
+}.store(getVersioningFile().outputStream(), null)
+
+private fun getVersioningFile(): File = File("version.properties")

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,3 @@
+version.major=1
+version.minor=0
+version.patch=0-SNAPSHOT

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,2 @@
-version.major=1
-version.minor=0
-version.patch=0-SNAPSHOT
+#Wed Apr 01 19:55:45 PDT 2020
+version=1.0.0-SNAPSHOT


### PR DESCRIPTION
Delegating versioning to [`buildSrc`](https://github.com/patxibocos/poetimizely/tree/versioning-to-buildSrc/buildSrc) module.
Here is my proposal for tagging/releasing:
- Whenever we want to release a new version of the plugin we will create a new GitHub release (without publishing it yet) using as name the version (`X.Y.Z`).
- I will create another GitHub action/workflow to listen for release creations that will call the [`bumpVersion`](https://github.com/patxibocos/poetimizely/pull/30/files#diff-392475fdf2bc320d17762ed97109a121R77) Gradle task. The release name will be picked as the new library version. So a new commit will be added to bump the version, and it'll be also tagged.
- When the release is published, the already existing `publish` GitHub workflow will run (we need to adapt the workflow in order to make the checkout on the tag whose name is equal to the release name).

🔝 I think we can also simplify that just creating the final release and then making the CI run the bumping and moving the tag to that new commit (combining steps 1 and 2).

Another simpler approach I am thinking about is not storing the version in the code, and then pass the version property when running the `publishPlugins` task:
```
./gradlew publishPlugins -Pgradle.publish.key=… -Pgradle.publish.secret=… -Pversion=…
```
In this case we would just need to listen for releases creation and then trigger the workflow.
I don't like from this approach that is a little bit obscure as we don't have the version stored in any place :/