### PR TITLE
Experiments contained in an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ interface BaseExperiment<V : BaseVariation> {
     val variations: Array<V>
 }
 
-fun Optimizely.getAllExperiments(): List<BaseExperiment<out BaseVariation>> = listOf(ExampleExperiment)
+fun Optimizely.getAllExperiments(): List<BaseExperiment<out BaseVariation>> = 
+    listOf(Experiments.ExampleExperiment)
 
 fun <V : BaseVariation> Optimizely.getVariationForExperiment(
     experiment: BaseExperiment<out V>,
@@ -114,10 +115,12 @@ enum class ExampleExperimentVariations : BaseVariation {
     }
 }
 
-object ExampleExperiment : BaseExperiment<ExampleExperimentVariations> {
-    override val key: String = "example-experiment"
-    override val variations: Array<ExampleExperimentVariations> =
-        ExampleExperimentVariations.values()
+object Experiments {
+    object ExampleExperiment : BaseExperiment<ExampleExperimentVariations> {
+        override val key: String = "example-experiment"
+        override val variations: Array<ExampleExperimentVariations> =
+            ExampleExperimentVariations.values()
+    }
 }
 ```
 
@@ -134,5 +137,5 @@ fun Optimizely.isFeatureEnabled(
     feature: Features,
     userId: String,
     attributes: Map<String, Any> = emptyMap()
-): Boolean = optimizely.isFeatureEnabled(feature.key, userId, attributes)
+): Boolean = this.isFeatureEnabled(feature.key, userId, attributes)
 ```

--- a/src/main/kotlin/com/patxi/poetimizely/generator/ExperimentsGenerator.kt
+++ b/src/main/kotlin/com/patxi/poetimizely/generator/ExperimentsGenerator.kt
@@ -28,12 +28,14 @@ class ExperimentsGenerator(private val packageName: String) {
                 addType(baseExperimentTypeSpec())
                 addFunction(getAllExperimentsFunSpec(optimizelyExperiments))
                 addFunction(getVariationForExperimentFunSpec())
+                val experimentsObjectBuilder = TypeSpec.objectBuilder("Experiments")
                 optimizelyExperiments.forEach { experiment ->
                     val variationsEnumClassName =
                         ClassName(packageName, experiment.key.optimizelyExperimentKeyToVariationEnumName())
                     addType(experimentVariationsEnumTypeSpec(variationsEnumClassName, experiment.variations))
-                    addType(experimentObjectTypeSpec(variationsEnumClassName, experiment))
+                    experimentsObjectBuilder.addType(experimentObjectTypeSpec(variationsEnumClassName, experiment))
                 }
+                addType(experimentsObjectBuilder.build())
             }.build().run {
                 StringWriter().also { appendable: Appendable ->
                     this.writeTo(appendable)
@@ -101,7 +103,7 @@ class ExperimentsGenerator(private val packageName: String) {
                 )
             )
             .addStatement("""return listOf(${optimizelyExperiments.joinToString {
-                it.key.optimizelyExperimentKeyToObjectName()
+                "Experiments.${it.key.optimizelyExperimentKeyToObjectName()}"
             }})""".trimIndent())
             .build()
 

--- a/src/test/kotlin/com/patxi/poetimizely/generator/ExperimentsGeneratorTest.kt
+++ b/src/test/kotlin/com/patxi/poetimizely/generator/ExperimentsGeneratorTest.kt
@@ -44,7 +44,7 @@ class ExperimentsGeneratorTest : BehaviorSpec({
                         this.map { it.getFieldValue("key") as String } shouldContainExactlyInAnyOrder optimizelyExperiment.variations.map { it.key }
                     }
                     // Experiment object
-                    val experimentClass = loadClass("TestExperiment")
+                    val experimentClass = loadClass("Experiments\$TestExperiment")
                     val experimentObject = experimentClass.getField("INSTANCE").get(null)
                     experimentObject.getFieldValue("key") shouldBe experimentKey
                     experimentObject.getFieldValue("variations") shouldBe variationsClass.enumConstants


### PR DESCRIPTION
In order to have a more consistent API, I propose having all the experiments contained in a Kotlin object like below:
```kotlin
object Experiments {
  object TestExperiment...
}
```
So the API for using experiments would be:
```kotlin
optimizely.getVariationForExperiment(Experiments.TestExperiment)
```
Features are already "scoped" as they are contained in an enum.
```kotlin
optimizely.isFeatureEnabled(Features.TestFeature)
```