### PR TITLE
Removing BaseExperiment class from generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,17 +91,11 @@ interface BaseVariation {
     val key: String
 }
 
-interface BaseExperiment<V : BaseVariation> {
-    val key: String
-
-    val variations: Array<V>
-}
-
-fun Optimizely.getAllExperiments(): List<BaseExperiment<out BaseVariation>> = 
+fun Optimizely.getAllExperiments(): List<Experiments<out BaseVariation>> =
     listOf(Experiments.ExampleExperiment)
 
 fun <V : BaseVariation> Optimizely.getVariationForExperiment(
-    experiment: BaseExperiment<out V>,
+    experiment: Experiments<out V>,
     userId: String,
     attributes: Map<String, Any> = emptyMap()
 ): V? {
@@ -115,12 +109,14 @@ enum class ExampleExperimentVariations : BaseVariation {
     }
 }
 
-object Experiments {
-    object ExampleExperiment : BaseExperiment<ExampleExperimentVariations> {
-        override val key: String = "example-experiment"
-        override val variations: Array<ExampleExperimentVariations> =
-            ExampleExperimentVariations.values()
-    }
+sealed class Experiments<V : BaseVariation>(
+    val key: String,
+    val variations: Array<V>
+) {
+    object ExampleExperiment : Experiments<ExampleExperimentVariations> (
+        "example-experiment",
+        ExampleExperimentVariations.values()
+    )
 }
 ```
 

--- a/generator/src/test/kotlin/com/patxi/poetimizely/generator/ExperimentsGeneratorTest.kt
+++ b/generator/src/test/kotlin/com/patxi/poetimizely/generator/ExperimentsGeneratorTest.kt
@@ -1,9 +1,9 @@
 package com.patxi.poetimizely.generator
 
 import com.optimizely.ab.Optimizely
-import com.patxi.poetimizely.matchers.publicStaticMethod
 import com.patxi.poetimizely.generator.optimizely.OptimizelyExperiment
 import com.patxi.poetimizely.generator.optimizely.OptimizelyVariation
+import com.patxi.poetimizely.matchers.publicStaticMethod
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.BehaviorSpec
@@ -43,12 +43,12 @@ class ExperimentsGeneratorTest : BehaviorSpec({
                         this.map { it.getFieldValue("key") as String } shouldContainExactlyInAnyOrder optimizelyExperiment.variations.map { it.key }
                     }
                     // Experiment object
-                    val experimentClass = loadClass("Experiments\$TestExperiment")
-                    val experimentObject = experimentClass.getField("INSTANCE").get(null)
-                    experimentObject.getFieldValue("key") shouldBe experimentKey
-                    experimentObject.getFieldValue("variations") shouldBe variationsClass.enumConstants
+                    val testExperimentClass = loadClass("Experiments\$TestExperiment")
+                    val experimentObject = testExperimentClass.getField("INSTANCE").get(null)
+                    experimentObject.getFieldValueFromParentClass("key") shouldBe experimentKey
+                    experimentObject.getFieldValueFromParentClass("variations") shouldBe variationsClass.enumConstants
                     // Optimizely extension functions
-                    val baseExperimentClass = loadClass("BaseExperiment")
+                    val experimentClass = loadClass("Experiments")
                     val extensionFunctionContainerClass = loadClass("ExperimentsKt")
                     with(extensionFunctionContainerClass) {
                         this shouldHave publicStaticMethod("getAllExperiments", Optimizely::class.java)
@@ -57,7 +57,7 @@ class ExperimentsGeneratorTest : BehaviorSpec({
                         this shouldHave publicStaticMethod(
                             "getVariationForExperiment",
                             Optimizely::class.java,
-                            baseExperimentClass,
+                            experimentClass,
                             String::class.java,
                             Map::class.java
                         )
@@ -70,3 +70,6 @@ class ExperimentsGeneratorTest : BehaviorSpec({
 
 private fun Any.getFieldValue(fieldName: String): Any =
     javaClass.getDeclaredField(fieldName).apply { isAccessible = true }.get(this)
+
+private fun Any.getFieldValueFromParentClass(fieldName: String): Any =
+    javaClass.superclass.getDeclaredField(fieldName).apply { isAccessible = true }.get(this)


### PR DESCRIPTION
Previously Experiments code looked like:

```kotlin
interface BaseVariation {
    val key: String
}

interface BaseExperiment<V : BaseVariation> {
    val key: String

    val variations: Array<V>
}

enum class ExampleExperimentVariations : BaseVariation {
    EXAMPLE_VARIATION {
        override val key: String = "example-variation"
    }
}

object Experiments {
    object ExampleExperiment : BaseExperiment<ExampleExperimentVariations> {
        override val key: String = "example-experiment"
        override val variations: Array<ExampleExperimentVariations> =
            ExampleExperimentVariations.values()
    }
}
```

with these changes now gets better:
```kotlin
interface BaseVariation {
    val key: String
}

enum class ExampleExperimentVariations : BaseVariation {
    EXAMPLE_VARIATION {
        override val key: String = "example-variation"
    }
}

sealed class Experiments<V : BaseVariation>(
    val key: String,
    val variations: Array<V>
) {
    object ExampleExperiment : Experiments<ExampleExperimentVariations >(
        "example-experiment",
        ExampleExperimentVariations.values()
    )
}
```

This code will be pretty similar as the new one proposed for features in https://github.com/patxibocos/poetimizely/issues/43#issuecomment-626056318